### PR TITLE
change assert(false) to runtime error

### DIFF
--- a/towr/include/towr/variables/node_spline.h
+++ b/towr/include/towr/variables/node_spline.h
@@ -99,7 +99,8 @@ public:
    *             n: Number of optimized durations.
    */
   virtual Jacobian
-  GetJacobianOfPosWrtDurations(double t) const { assert(false); } // durations are fixed here
+  GetJacobianOfPosWrtDurations(double t) const {
+    throw std::runtime_error("[NodeSpline::GetJacobianOfPosWrtDurations] durations are fixed here"); }
 
 protected:
   /**

--- a/towr/src/biped_gait_generator.cc
+++ b/towr/src/biped_gait_generator.cc
@@ -57,7 +57,7 @@ BipedGaitGenerator::SetCombo (Combos combo)
     case C2: SetGaits({Stand, Hop1, Hop1, Hop1, Stand});       break;
     case C3: SetGaits({Stand, Hop1, Hop2, Hop2, Stand});       break;
     case C4: SetGaits({Stand, Hop5, Hop5, Hop5, Stand});       break;
-    default: assert(false); std::cout << "Gait not defined\n"; break;
+    default: throw std::runtime_error("[BipedGaitGenerator::SetCombo] Gait not defined");
   }
 }
 
@@ -75,7 +75,7 @@ BipedGaitGenerator::GetGait (Gaits gait) const
     case Hop2:    return GetStrideLeftHop();
     case Hop3:    return GetStrideRightHop();
     case Hop5:    return GetStrideGallopHop();
-    default: assert(false); // gait not implemented
+    default: throw std::runtime_error("[BipedGaitGenerator::GetGait] Gait not implemented");
   }
 }
 

--- a/towr/src/gait_generator.cc
+++ b/towr/src/gait_generator.cc
@@ -47,7 +47,7 @@ GaitGenerator::MakeGaitGenerator(int leg_count)
     case 1: return std::make_shared<MonopedGaitGenerator>();   break;
     case 2: return std::make_shared<BipedGaitGenerator>();     break;
     case 4: return std::make_shared<QuadrupedGaitGenerator>(); break;
-    default: assert(false); break; // Error: Not implemented
+    default: throw std::runtime_error("[GaitGenerator::MakeGaitGenerator] Not implemented");
   }
 }
 

--- a/towr/src/height_map.cc
+++ b/towr/src/height_map.cc
@@ -45,7 +45,7 @@ HeightMap::MakeTerrain (TerrainID type)
     case SlopeID:     return std::make_shared<Slope>(); break;
     case ChimneyID:   return std::make_shared<Chimney>(); break;
     case ChimneyLRID: return std::make_shared<ChimneyLR>(); break;
-    default: assert(false); break;
+    default: throw std::runtime_error("[HeightMap::MakeTerrain] Unknown terrain ID");
   }
 }
 
@@ -55,7 +55,7 @@ HeightMap::GetDerivativeOfHeightWrt (Dim2D dim, double x, double y) const
   switch (dim) {
     case X: return GetHeightDerivWrtX(x,y);
     case Y: return GetHeightDerivWrtY(x,y);
-    default: assert(false); // derivative dimension not implemented
+    default: throw std::runtime_error("[HeightMap::GetDerivativeOfHeightWrt] Derivative dimension not implemented");
   }
 }
 
@@ -73,7 +73,7 @@ HeightMap::GetBasis (Direction basis, double x, double y,
     case Normal:   return GetNormal(x,y, deriv);
     case Tangent1: return GetTangent1(x,y, deriv);
     case Tangent2: return GetTangent2(x,y, deriv);
-    default: assert(false); // basis does not exist
+    default: throw std::runtime_error("[HeightMap::GetDerivativeOfHeightWrt] Basis does not exist");
   }
 }
 
@@ -159,7 +159,7 @@ HeightMap::GetSecondDerivativeOfHeightWrt (Dim2D dim1, Dim2D dim2,
     if (dim2 == Y_) return GetHeightDerivWrtYY(x,y);
   }
 
-  assert(false); // second derivative not specified.
+  throw std::runtime_error("[HeightMap::GetSecondDerivativeOfHeightWrt] Second derivative not specified");
 }
 
 } /* namespace towr */

--- a/towr/src/monoped_gait_generator.cc
+++ b/towr/src/monoped_gait_generator.cc
@@ -55,7 +55,7 @@ MonopedGaitGenerator::GetGait (Gaits gait) const
     case Flight:  return GetStrideFlight();
     case Hop1:    return GetStrideHop();
     case Hop2:    return GetStrideHopLong();
-    default: assert(false); // gait not implemented
+    default: throw std::runtime_error("[MonopedGaitGenerator::GetGait] Gait not implemented");
   }
 }
 

--- a/towr/src/nodes_variables_phase_based.cc
+++ b/towr/src/nodes_variables_phase_based.cc
@@ -144,6 +144,7 @@ NodesVariablesPhaseBased::GetPolyIDAtStartOfPhase (int phase) const
   for (int i=0; i<polynomial_info_.size(); ++i)
     if (polynomial_info_.at(i).phase_ == phase)
       return i;
+  return 0;
 }
 
 Eigen::Vector3d

--- a/towr/src/polynomial.cc
+++ b/towr/src/polynomial.cc
@@ -67,7 +67,7 @@ Polynomial::GetDerivativeWrtCoeff (double t, Dx deriv, Coefficients c) const
     case kPos:   return               std::pow(t,c);         break;
     case kVel:   return c>=B? c*      std::pow(t,c-1) : 0.0; break;
     case kAcc:   return c>=C? c*(c-1)*std::pow(t,c-2) : 0.0; break;
-    default: assert(false); // derivative not defined
+    default: throw std::runtime_error("[CubicHermitePolynomial::GetDerivativeWrtCoeff] derivative not defined");
   }
 }
 
@@ -116,7 +116,7 @@ CubicHermitePolynomial::GetDerivativeWrtStartNode (Dx dfdt,
     case kAcc:
       return GetDerivativeOfAccWrtStartNode(node_derivative, t_local);
     default:
-      assert(false); // derivative not yet implemented
+      throw std::runtime_error("[CubicHermitePolynomial::GetDerivativeWrtStartNode] derivative not yet implemented");
   }
 }
 
@@ -133,7 +133,7 @@ CubicHermitePolynomial::GetDerivativeWrtEndNode (Dx dfdt,
     case kAcc:
       return GetDerivativeOfAccWrtEndNode(node_derivative, t_local);
     default:
-      assert(false); // derivative not yet implemented
+      throw std::runtime_error("[CubicHermitePolynomial::GetDerivativeWrtEndNode] derivative not yet implemented");
   }
 }
 
@@ -150,7 +150,7 @@ CubicHermitePolynomial::GetDerivativeOfPosWrtStartNode(Dx node_value,
   switch (node_value) {
     case kPos: return (2*t3)/T3 - (3*t2)/T2 + 1;
     case kVel: return t - (2*t2)/T + t3/T2;
-    default: assert(false); // only derivative wrt nodes values calculated
+    default: throw std::runtime_error("[CubicHermitePolynomial::GetDerivativeOfPosWrtStartNode] only derivative wrt nodes values calculated");
   }
 }
 
@@ -166,7 +166,7 @@ CubicHermitePolynomial::GetDerivativeOfVelWrtStartNode (Dx node_value,
   switch (node_value) {
     case kPos: return (6*t2)/T3 - (6*t)/T2;
     case kVel: return (3*t2)/T2 - (4*t)/T + 1;
-    default: assert(false); // only derivative wrt nodes values calculated
+    default: throw std::runtime_error("[CubicHermitePolynomial::GetDerivativeOfVelWrtStartNode] only derivative wrt nodes values calculated");
   }
 }
 
@@ -181,7 +181,7 @@ CubicHermitePolynomial::GetDerivativeOfAccWrtStartNode (Dx node_value,
   switch (node_value) {
     case kPos: return (12*t)/T3 - 6/T2;
     case kVel: return (6*t)/T2 - 4/T;
-    default: assert(false); // only derivative wrt nodes values calculated
+    default: throw std::runtime_error("[CubicHermitePolynomial::GetDerivativeOfAccWrtStartNode] only derivative wrt nodes values calculated");
   }
 }
 
@@ -198,7 +198,7 @@ CubicHermitePolynomial::GetDerivativeOfPosWrtEndNode (Dx node_value,
   switch (node_value) {
     case kPos: return (3*t2)/T2 - (2*t3)/T3;
     case kVel: return t3/T2 - t2/T;
-    default: assert(false); // only derivative wrt nodes values calculated
+    default: throw std::runtime_error("[CubicHermitePolynomial::GetDerivativeOfPosWrtEndNode] only derivative wrt nodes values calculated");
   }
 }
 
@@ -214,7 +214,7 @@ CubicHermitePolynomial::GetDerivativeOfVelWrtEndNode (Dx node_value,
   switch (node_value) {
     case kPos: return (6*t)/T2 - (6*t2)/T3;
     case kVel: return (3*t2)/T2 - (2*t)/T;
-    default: assert(false); // only derivative wrt nodes values calculated
+    default: throw std::runtime_error("[CubicHermitePolynomial::GetDerivativeOfVelWrtEndNode] only derivative wrt nodes values calculated");
   }
 }
 
@@ -229,7 +229,7 @@ CubicHermitePolynomial::GetDerivativeOfAccWrtEndNode (Dx node_value,
   switch (node_value) {
     case kPos: return 6/T2 - (12*t)/T3;
     case kVel: return (6*t)/T2 - 2/T;
-    default: assert(false); // only derivative wrt nodes values calculated
+    default: throw std::runtime_error("[CubicHermitePolynomial::GetDerivativeOfAccWrtEndNode] only derivative wrt nodes values calculated");
   }
 }
 

--- a/towr/src/quadruped_gait_generator.cc
+++ b/towr/src/quadruped_gait_generator.cc
@@ -82,7 +82,7 @@ QuadrupedGaitGenerator::SetCombo (Combos combo)
     case C2: SetGaits({Stand, Run3, Run3, Run3, Run3E, Stand}); break; // pace
     case C3: SetGaits({Stand, Hop1, Hop1, Hop1, Hop1E, Stand}); break; // bound
     case C4: SetGaits({Stand, Hop3, Hop3, Hop3, Hop3E, Stand}); break; // gallop
-    default: assert(false); std::cout << "Gait not defined\n"; break;
+    default: throw std::runtime_error("[QuadrupedGaitGenerator::SetCombo] Gait not defined");
   }
 }
 
@@ -106,7 +106,7 @@ QuadrupedGaitGenerator::GetGait(Gaits gait) const
     case Hop3:    return GetStrideGallop();
     case Hop3E:   return RemoveTransition(GetStrideGallop());
     case Hop5:    return GetStrideLimp();
-    default: assert(false); // gait not implemented
+    default: throw std::runtime_error("[QuadrupedGaitGenerator::QuadrupedGaitGenerator] Gait not implemented");
   }
 }
 

--- a/towr/src/spline.cc
+++ b/towr/src/spline.cc
@@ -62,7 +62,7 @@ Spline::GetSegmentID(double t_global, const VecTimes& durations)
      i++;
    }
 
-   assert(false); // this should never be reached
+  throw std::runtime_error("[Spline::GetSegmentID] this should never be reached");
 }
 
 std::pair<int,double>


### PR DESCRIPTION
with assert(false), we reach the end of functions in release mode without returning, resulting in undefined behavior.
Changing to runtime error fixes that issue. The code can now be compiled with -Werror=return-type.

@awinkler, pushing here to our fork, let me know if you want this pushed to the original repo.